### PR TITLE
Add Haml CoffeeScript filter compatibility

### DIFF
--- a/lib/coffee-rails-source-maps.rb
+++ b/lib/coffee-rails-source-maps.rb
@@ -59,7 +59,8 @@ if Rails.env.development?
   module Tilt
     class CoffeeScriptTemplate < Template
       def evaluate(scope, locals, &block)
-        @output ||= CoffeeScript.compile(data, options.merge(:pathname => scope.pathname))
+        pathname = scope.respond_to?(:pathname) ? scope.pathname : nil
+        @output ||= CoffeeScript.compile(data, options.merge(:pathname => pathname))
       end
     end
   end


### PR DESCRIPTION
- Ignore pathname if it's not available
  from the scope in which evaluation
  takes place

This relates to issue #4. I'm not sure why this patch didn't work for @jkchow, but it's working well for me.
