### PR TITLE
Put the comment at the end of the file.

### DIFF
--- a/lib/coffee-rails-source-maps.rb
+++ b/lib/coffee-rails-source-maps.rb
@@ -45,7 +45,7 @@ if Rails.env.development?
           map_file.open('w')    {|f| f.puts ret["v3SourceMap"]}
 
           comment = "//@ sourceMappingURL=/#{map_file.relative_path_from(Rails.root.join("public"))}\n"
-          return comment + ret['js']
+          return ret['js'] + comment
         end
 
       end


### PR DESCRIPTION
The generated source maps were off by one line, because the source map comment was prepended to the generated source after creating the map.

This changes it to add the comment to the end of the generated source, which avoids shifting line numbers and complies with the recommendation in the Source Map Revision 3 Proposal (https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit)
