### PR TITLE
Fix for rails 4 & chrome 28.0.1500.71

### DIFF
--- a/lib/coffee-rails-source-maps.rb
+++ b/lib/coffee-rails-source-maps.rb
@@ -44,7 +44,7 @@ if Rails.env.development?
           coffee_file.open('w') {|f| f.puts script }
           map_file.open('w')    {|f| f.puts ret["v3SourceMap"]}
 
-          comment = "//# sourceMappingURL=/#{map_file.relative_path_from(Rails.root.join("public"))}\n"
+          comment = "//@ sourceMappingURL=/#{map_file.relative_path_from(Rails.root.join("public"))}\n"
           return ret['js'] + comment
         end
 


### PR DESCRIPTION
This small change makes source maps work in rails 4 & chrome. I'm not sure about other browsers, this for sure needs further investigation.
