### PR TITLE
Ability to disable CoffeeScript source maps

### DIFF
--- a/lib/coffee-rails-source-maps.rb
+++ b/lib/coffee-rails-source-maps.rb
@@ -3,7 +3,7 @@ require "coffee-rails-source-maps/version"
 # Based on https://gist.github.com/naan/5096056
 # config/initializers/source_maps.rb
 
-if Rails.env.development?
+if Rails.env.development? && ENV['CS_SOURCE_MAPS'] != 'false'
   require 'coffee-script' #make sure CoffeeScript is loaded before we overwrite it.
   module CoffeeScript
 


### PR DESCRIPTION
`CS_SOURCE_MAPS=false` env variable will disable CoffeeScript source maps
