### PR TITLE
Fixed filenames for .coffee files that contains dot

### DIFF
--- a/lib/coffee-rails-source-maps.rb
+++ b/lib/coffee-rails-source-maps.rb
@@ -22,7 +22,7 @@ if Rails.env.development?
         if pathname.nil?
           return Source.context.call("CoffeeScript.compile", script, options)
         else
-          clean_name = pathname.basename.to_s.split(".").first
+          clean_name = File.basename(pathname.basename, File.extname(pathname.basename))
 
           rel_path = if pathname.to_s.start_with?(Bundler.bundle_path.to_s)
             Pathname('bundler').join(pathname.relative_path_from(Bundler.bundle_path)).dirname


### PR DESCRIPTION
When the .coffee file name containing the dot, for example "views.users.list.coffee", .map file created with only the first part of the filename, which entailed the loss of .map files and caused breakpoints in Chrome DevTools didn't works.

