### PR TITLE
Patched sprockets for rails 4.0.13

### DIFF
--- a/lib/coffee-rails-source-maps.rb
+++ b/lib/coffee-rails-source-maps.rb
@@ -5,11 +5,13 @@ require "coffee-rails-source-maps/version"
 
 if Rails.env.development?
   require 'coffee-script' #make sure CoffeeScript is loaded before we overwrite it.
+
   module CoffeeScript
 
     class << self
 
       def compile(script, options = {})
+
         script = script.read if script.respond_to?(:read)
 
         if options.key?(:no_wrap) && !options.key?(:bare)
@@ -69,15 +71,47 @@ if Rails.env.development?
   end
 
   # Monkeypatch this method to include the scripts' pathname
-  require 'tilt/coffee'
+  # This works for rails 4.0.13
+  require 'sprockets/autoload'
+  module Sprockets
+    # Processor engine class for the CoffeeScript compiler.
+    # Depends on the `coffee-script` and `coffee-script-source` gems.
+    #
+    # For more infomation see:
+    #
+    #   https://github.com/josh/ruby-coffee-script
+    #
+    module CoffeeScriptProcessor
+      VERSION = '1'
 
-  module Tilt
-    class CoffeeScriptTemplate < Template
-      def evaluate(scope, locals, &block)
-        pathname = scope.respond_to?(:pathname) ? scope.pathname : nil
-        @output ||= CoffeeScript.compile(data, options.merge(:pathname => pathname))
+      def self.cache_key
+        @cache_key ||= "#{name}:#{Autoload::CoffeeScript::Source.version}:#{VERSION}".freeze
+      end
+
+      def self.call(input)
+        data = input[:data]
+        input[:cache].fetch([self.cache_key, data]) do
+          Autoload::CoffeeScript.compile(data, {pathname: Pathname.new(input[:filename])})
+        end
       end
     end
   end
+
+  # # Monkeypatch this method to include the scripts' pathname
+  # # This works for rails 4.2.0
+  # require 'tilt/coffee'
+
+  # module Tilt
+  #   class CoffeeScriptTemplate < Template
+  #     def evaluate(scope, locals, &block)
+
+  #       raise "rene"
+
+        
+  #       pathname = scope.respond_to?(:pathname) ? scope.pathname : nil
+  #       @output ||= CoffeeScript.compile(data, options.merge(:pathname => pathname))
+  #     end
+  #   end
+  # end
 
 end

--- a/lib/coffee-rails-source-maps.rb
+++ b/lib/coffee-rails-source-maps.rb
@@ -82,8 +82,6 @@ if Rails.env.development?
     #   https://github.com/josh/ruby-coffee-script
     #
     module CoffeeScriptProcessor
-      VERSION = '1'
-
       def self.cache_key
         @cache_key ||= "#{name}:#{Autoload::CoffeeScript::Source.version}:#{VERSION}".freeze
       end


### PR DESCRIPTION
In rails 4.0.13 i needed to patch sprockets instead of Tilt so... did that
